### PR TITLE
Remove allocations from Sink & Producer

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/SafeObserver.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/SafeObserver.cs
@@ -9,27 +9,15 @@ namespace System.Reactive
     // its implementation aspects.
     //
 
-    internal sealed class SafeObserver<TSource> : IObserver<TSource>
+    internal sealed class SafeObserver<TSource> : Sink<TSource>, IObserver<TSource>
     {
-        private readonly IObserver<TSource> _observer;
-        private readonly IDisposable _disposable;
-
-        public static IObserver<TSource> Create(IObserver<TSource> observer, IDisposable disposable)
+        public static SafeObserver<TSource> Create(IObserver<TSource> observer)
         {
-            if (observer is AnonymousObserver<TSource> a)
-            {
-                return a.MakeSafe(disposable);
-            }
-            else
-            {
-                return new SafeObserver<TSource>(observer, disposable);
-            }
+            return new SafeObserver<TSource>(observer);
         }
 
-        private SafeObserver(IObserver<TSource> observer, IDisposable disposable)
+        private SafeObserver(IObserver<TSource> observer) : base(observer)
         {
-            _observer = observer;
-            _disposable = disposable;
         }
 
         public void OnNext(TSource value)
@@ -44,7 +32,7 @@ namespace System.Reactive
             {
                 if (!__noError)
                 {
-                    _disposable.Dispose();
+                    Dispose();
                 }
             }
         }
@@ -57,7 +45,7 @@ namespace System.Reactive
             }
             finally
             {
-                _disposable.Dispose();
+                Dispose();
             }
         }
 
@@ -69,7 +57,7 @@ namespace System.Reactive
             }
             finally
             {
-                _disposable.Dispose();
+                Dispose();
             }
         }
     }


### PR DESCRIPTION
These changes are supposed to reduce allocation in `Sink` and `Producer` instances. I couldn't really test them because I'm on Windows 7 right now and Rx.NET simply won't properly build.

There is no need for the two argument `Sink` constructor, but I did not want to change 191 locations of `CreateSink` usages.