### PR TITLE
4.x: TailRecursiveSink optimizations

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/ConcatSink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ConcatSink.cs
@@ -15,6 +15,6 @@ namespace System.Reactive
 
         protected override IEnumerable<IObservable<TSource>> Extract(IObservable<TSource> source) => (source as IConcatenatable<TSource>)?.GetSources();
 
-        public override void OnCompleted() => _recurse();
+        public override void OnCompleted() => Recurse();
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Internal/Producer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Producer.cs
@@ -69,11 +69,11 @@ namespace System.Reactive
             public IObserver<TSource> observer;
         }
 
-        static readonly Func<IScheduler, State, IDisposable> RunRun = (_, x) =>
+        static IDisposable RunRun(IScheduler _, State x)
         {
             x.subscription.Disposable = x.parent.Run(x.observer);
             return Disposable.Empty;
-        };
+        }
 
         /// <summary>
         /// Core implementation of the query operator, called upon a new subscription to the producer object.
@@ -165,11 +165,11 @@ namespace System.Reactive
             public SingleAssignmentDisposable inner;
         }
 
-        static readonly Func<IScheduler, State, IDisposable> RunRun = (_, x) =>
+        static IDisposable RunRun(IScheduler _, State x)
         {
             x.inner.Disposable = x.parent.Run(x.sink);
             return Disposable.Empty;
-        };
+        }
 
         /// <summary>
         /// Core implementation of the query operator, called upon a new subscription to the producer object.

--- a/Rx.NET/Source/src/System.Reactive/Internal/Producer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Producer.cs
@@ -4,6 +4,7 @@
 
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
+using System.Threading;
 
 namespace System.Reactive
 {
@@ -20,7 +21,7 @@ namespace System.Reactive
     /// Base class for implementation of query operators, providing performance benefits over the use of Observable.Create.
     /// </summary>
     /// <typeparam name="TSource">Type of the resulting sequence's elements.</typeparam>
-    internal abstract class Producer<TSource> : IProducer<TSource>
+    internal abstract class BasicProducer<TSource> : IProducer<TSource>
     {
         /// <summary>
         /// Publicly visible Subscribe method.
@@ -32,17 +33,12 @@ namespace System.Reactive
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
 
-            return SubscribeRaw(observer, true);
+            return SubscribeRaw(observer, enableSafeguard: true);
         }
 
         public IDisposable SubscribeRaw(IObserver<TSource> observer, bool enableSafeguard)
         {
-            var state = new State();
-            state.observer = observer;
-            state.sink = new SingleAssignmentDisposable();
-            state.subscription = new SingleAssignmentDisposable();
-
-            var d = StableCompositeDisposable.Create(state.sink, state.subscription);
+            var subscription = new SingleAssignmentDisposable();
 
             //
             // See AutoDetachObserver.cs for more information on the safeguarding requirement and
@@ -50,36 +46,31 @@ namespace System.Reactive
             //
             if (enableSafeguard)
             {
-                state.observer = SafeObserver<TSource>.Create(state.observer, d);
+                observer = SafeObserver<TSource>.Create(observer, subscription);
             }
 
             if (CurrentThreadScheduler.IsScheduleRequired)
             {
+                var state = new State { subscription = subscription, observer = observer };
                 CurrentThreadScheduler.Instance.Schedule(state, Run);
             }
             else
             {
-                state.subscription.Disposable = Run(state.observer, state.subscription, state.Assign);
+                subscription.Disposable = Run(observer);
             }
 
-            return d;
+            return subscription;
         }
 
         private struct State
         {
-            public SingleAssignmentDisposable sink;
             public SingleAssignmentDisposable subscription;
             public IObserver<TSource> observer;
-
-            public void Assign(IDisposable s)
-            {
-                sink.Disposable = s;
-            }
         }
 
         private IDisposable Run(IScheduler _, State x)
         {
-            x.subscription.Disposable = this.Run(x.observer, x.subscription, x.Assign);
+            x.subscription.Disposable = Run(x.observer);
             return Disposable.Empty;
         }
 
@@ -87,10 +78,103 @@ namespace System.Reactive
         /// Core implementation of the query operator, called upon a new subscription to the producer object.
         /// </summary>
         /// <param name="observer">Observer to send notifications on. The implementation of a producer must ensure the correct message grammar on the observer.</param>
-        /// <param name="cancel">The subscription disposable object returned from the Run call, passed in such that it can be forwarded to the sink, allowing it to dispose the subscription upon sending a final message (or prematurely for other reasons).</param>
-        /// <param name="setSink">Callback to communicate the sink object to the subscriber, allowing consumers to tunnel a Dispose call into the sink, which can stop the processing.</param>
         /// <returns>Disposable representing all the resources and/or subscriptions the operator uses to process events.</returns>
         /// <remarks>The <paramref name="observer">observer</paramref> passed in to this method is not protected using auto-detach behavior upon an OnError or OnCompleted call. The implementation must ensure proper resource disposal and enforce the message grammar.</remarks>
-        protected abstract IDisposable Run(IObserver<TSource> observer, IDisposable cancel, Action<IDisposable> setSink);
+        protected abstract IDisposable Run(IObserver<TSource> observer);
+    }
+
+    internal abstract class Producer<TTarget, TSink> : IProducer<TTarget>
+        where TSink : IDisposable
+    {
+        /// <summary>
+        /// Publicly visible Subscribe method.
+        /// </summary>
+        /// <param name="observer">Observer to send notifications on. The implementation of a producer must ensure the correct message grammar on the observer.</param>
+        /// <returns>IDisposable to cancel the subscription. This causes the underlying sink to be notified of unsubscription, causing it to prevent further messages from being sent to the observer.</returns>
+        public IDisposable Subscribe(IObserver<TTarget> observer)
+        {
+            if (observer == null)
+                throw new ArgumentNullException(nameof(observer));
+
+            return SubscribeRaw(observer, enableSafeguard: true);
+        }
+
+        public IDisposable SubscribeRaw(IObserver<TTarget> observer, bool enableSafeguard)
+        {
+            //This is passed to Sink creation and later assigned with the outcome of Run,
+            //so this allocation is (still) inevitable.
+            var runDisposable = new SingleAssignmentDisposable();
+
+            //This will only ever be allocated if we need to put a safeguard around the observer.
+            //or if the created Sink does not inherit from the internal Sink class (see below).
+            BinarySingleAssignmentDisposable safeObserverDisposable = null;
+
+            //
+            // See AutoDetachObserver.cs for more information on the safeguarding requirement and
+            // its implementation aspects.
+            //
+            if (enableSafeguard)
+            {
+                safeObserverDisposable = new BinarySingleAssignmentDisposable();
+                observer = SafeObserver<TTarget>.Create(observer, safeObserverDisposable);
+            }
+
+            var sink = CreateSink(observer, runDisposable);
+            var sinkIsInternal = sink is Sink<TTarget>;
+
+            if (!sinkIsInternal && safeObserverDisposable == null)
+            {
+                //If sink inherits from the internal class Sink<TTarget>, we know that disposing it
+                //will dispose the runDisposable passed in during Sink creation. Is is therefore
+                //sufficient, to continue working with sink. If not, we have to combine the sink and the run.
+                //Again, on the hot path, this allocation is avoided.
+                safeObserverDisposable = new BinarySingleAssignmentDisposable();
+            }
+
+            if (safeObserverDisposable != null)
+            {
+                //So we either needed to enable a safeguard or our Sink is some obscure type
+                //we don't know too much about...
+                safeObserverDisposable.Disposable1 = sink;
+
+                //...if the latter is true, also set the run.
+                if (!sinkIsInternal)
+                    safeObserverDisposable.Disposable2 = runDisposable;
+            }
+
+            if (CurrentThreadScheduler.IsScheduleRequired)
+            {
+                var state = new State { sink = sink, inner = runDisposable };
+
+                CurrentThreadScheduler.Instance.Schedule(state, Run);
+            }
+            else
+            {
+                runDisposable.Disposable = Run(sink);
+            }
+
+            //On the hot path, returning sink will suffice. This will save one allocation.
+            return safeObserverDisposable ?? (IDisposable)sink;
+        }
+
+        private struct State
+        {
+            public TSink sink;
+            public SingleAssignmentDisposable inner;
+        }
+
+        private IDisposable Run(IScheduler _, State x)
+        {
+            x.inner.Disposable = Run(x.sink);
+            return Disposable.Empty;
+        }
+
+        /// <summary>
+        /// Core implementation of the query operator, called upon a new subscription to the producer object.
+        /// </summary>
+        /// <param name="sink">The sink object.</param>
+        protected abstract IDisposable Run(TSink sink);
+
+        protected abstract TSink CreateSink(IObserver<TTarget> observer, IDisposable cancel);
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Internal/Producer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Producer.cs
@@ -4,7 +4,6 @@
 
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
-using System.Threading;
 
 namespace System.Reactive
 {
@@ -21,7 +20,7 @@ namespace System.Reactive
     /// Base class for implementation of query operators, providing performance benefits over the use of Observable.Create.
     /// </summary>
     /// <typeparam name="TSource">Type of the resulting sequence's elements.</typeparam>
-    internal abstract class BasicProducer<TSource> : IProducer<TSource>
+    internal abstract class Producer<TSource> : IProducer<TSource>
     {
         /// <summary>
         /// Publicly visible Subscribe method.
@@ -33,12 +32,17 @@ namespace System.Reactive
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
 
-            return SubscribeRaw(observer, enableSafeguard: true);
+            return SubscribeRaw(observer, true);
         }
 
         public IDisposable SubscribeRaw(IObserver<TSource> observer, bool enableSafeguard)
         {
-            var subscription = new SingleAssignmentDisposable();
+            var state = new State();
+            state.observer = observer;
+            state.sink = new SingleAssignmentDisposable();
+            state.subscription = new SingleAssignmentDisposable();
+
+            var d = StableCompositeDisposable.Create(state.sink, state.subscription);
 
             //
             // See AutoDetachObserver.cs for more information on the safeguarding requirement and
@@ -46,32 +50,36 @@ namespace System.Reactive
             //
             if (enableSafeguard)
             {
-                observer = SafeObserver<TSource>.Create(observer, subscription);
+                state.observer = SafeObserver<TSource>.Create(state.observer, d);
             }
 
             if (CurrentThreadScheduler.IsScheduleRequired)
             {
-                var state = new State { parent = this, subscription = subscription, observer = observer };
-                CurrentThreadScheduler.Instance.Schedule(state, RunRun);
+                CurrentThreadScheduler.Instance.Schedule(state, Run);
             }
             else
             {
-                subscription.Disposable = Run(observer);
+                state.subscription.Disposable = Run(state.observer, state.subscription, state.Assign);
             }
 
-            return subscription;
+            return d;
         }
 
         private struct State
         {
-            public BasicProducer<TSource> parent;
+            public SingleAssignmentDisposable sink;
             public SingleAssignmentDisposable subscription;
             public IObserver<TSource> observer;
+
+            public void Assign(IDisposable s)
+            {
+                sink.Disposable = s;
+            }
         }
 
-        static IDisposable RunRun(IScheduler _, State x)
+        private IDisposable Run(IScheduler _, State x)
         {
-            x.subscription.Disposable = x.parent.Run(x.observer);
+            x.subscription.Disposable = this.Run(x.observer, x.subscription, x.Assign);
             return Disposable.Empty;
         }
 
@@ -79,104 +87,10 @@ namespace System.Reactive
         /// Core implementation of the query operator, called upon a new subscription to the producer object.
         /// </summary>
         /// <param name="observer">Observer to send notifications on. The implementation of a producer must ensure the correct message grammar on the observer.</param>
+        /// <param name="cancel">The subscription disposable object returned from the Run call, passed in such that it can be forwarded to the sink, allowing it to dispose the subscription upon sending a final message (or prematurely for other reasons).</param>
+        /// <param name="setSink">Callback to communicate the sink object to the subscriber, allowing consumers to tunnel a Dispose call into the sink, which can stop the processing.</param>
         /// <returns>Disposable representing all the resources and/or subscriptions the operator uses to process events.</returns>
         /// <remarks>The <paramref name="observer">observer</paramref> passed in to this method is not protected using auto-detach behavior upon an OnError or OnCompleted call. The implementation must ensure proper resource disposal and enforce the message grammar.</remarks>
-        protected abstract IDisposable Run(IObserver<TSource> observer);
-    }
-
-    internal abstract class Producer<TTarget, TSink> : IProducer<TTarget>
-        where TSink : IDisposable
-    {
-        /// <summary>
-        /// Publicly visible Subscribe method.
-        /// </summary>
-        /// <param name="observer">Observer to send notifications on. The implementation of a producer must ensure the correct message grammar on the observer.</param>
-        /// <returns>IDisposable to cancel the subscription. This causes the underlying sink to be notified of unsubscription, causing it to prevent further messages from being sent to the observer.</returns>
-        public IDisposable Subscribe(IObserver<TTarget> observer)
-        {
-            if (observer == null)
-                throw new ArgumentNullException(nameof(observer));
-
-            return SubscribeRaw(observer, enableSafeguard: true);
-        }
-
-        public IDisposable SubscribeRaw(IObserver<TTarget> observer, bool enableSafeguard)
-        {
-            //This is passed to Sink creation and later assigned with the outcome of Run,
-            //so this allocation is (still) inevitable.
-            var runDisposable = new SingleAssignmentDisposable();
-
-            //This will only ever be allocated if we need to put a safeguard around the observer.
-            //or if the created Sink does not inherit from the internal Sink class (see below).
-            BinarySingleAssignmentDisposable safeObserverDisposable = null;
-
-            //
-            // See AutoDetachObserver.cs for more information on the safeguarding requirement and
-            // its implementation aspects.
-            //
-            if (enableSafeguard)
-            {
-                safeObserverDisposable = new BinarySingleAssignmentDisposable();
-                observer = SafeObserver<TTarget>.Create(observer, safeObserverDisposable);
-            }
-
-            var sink = CreateSink(observer, runDisposable);
-            var sinkIsInternal = sink is Sink<TTarget>;
-
-            if (!sinkIsInternal && safeObserverDisposable == null)
-            {
-                //If sink inherits from the internal class Sink<TTarget>, we know that disposing it
-                //will dispose the runDisposable passed in during Sink creation. Is is therefore
-                //sufficient, to continue working with sink. If not, we have to combine the sink and the run.
-                //Again, on the hot path, this allocation is avoided.
-                safeObserverDisposable = new BinarySingleAssignmentDisposable();
-            }
-
-            if (safeObserverDisposable != null)
-            {
-                //So we either needed to enable a safeguard or our Sink is some obscure type
-                //we don't know too much about...
-                safeObserverDisposable.Disposable1 = sink;
-
-                //...if the latter is true, also set the run.
-                if (!sinkIsInternal)
-                    safeObserverDisposable.Disposable2 = runDisposable;
-            }
-            
-            if (CurrentThreadScheduler.IsScheduleRequired)
-            {
-                var state = new State { parent = this, sink = sink, inner = runDisposable };
-
-                CurrentThreadScheduler.Instance.Schedule(state, RunRun);
-            }
-            else
-            {
-                runDisposable.Disposable = Run(sink);
-            }
-
-            //On the hot path, returning sink will suffice. This will save one allocation.
-            return safeObserverDisposable ?? (IDisposable)sink;
-        }
-
-        private struct State
-        {
-            public Producer<TTarget, TSink> parent;
-            public TSink sink;
-            public SingleAssignmentDisposable inner;
-        }
-
-        static IDisposable RunRun(IScheduler _, State x)
-        {
-            x.inner.Disposable = x.parent.Run(x.sink);
-            return Disposable.Empty;
-        }
-
-        /// <summary>
-        /// Core implementation of the query operator, called upon a new subscription to the producer object.
-        /// </summary>
-        /// <param name="sink">The sink object.</param>
-        protected abstract IDisposable Run(TSink sink);
-
-        protected abstract TSink CreateSink(IObserver<TTarget> observer, IDisposable cancel);
+        protected abstract IDisposable Run(IObserver<TSource> observer, IDisposable cancel, Action<IDisposable> setSink);
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Internal/TailRecursiveSink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/TailRecursiveSink.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
+using System.Threading;
 
 namespace System.Reactive
 {
@@ -15,38 +16,176 @@ namespace System.Reactive
         {
         }
 
-        private bool _isDisposed;
-        private SerialDisposable _subscription;
-        private AsyncLock _gate;
-        private Stack<IEnumerator<IObservable<TSource>>> _stack;
-        private Stack<int?> _length;
-        protected Action _recurse;
+        bool _isDisposed;
+
+        int trampoline;
+
+        IDisposable currentSubscription;
+
+        Stack<IEnumerator<IObservable<TSource>>> stack;
 
         public IDisposable Run(IEnumerable<IObservable<TSource>> sources)
         {
-            _isDisposed = false;
-            _subscription = new SerialDisposable();
-            _gate = new AsyncLock();
-            _stack = new Stack<IEnumerator<IObservable<TSource>>>();
-            _length = new Stack<int?>();
-
-            if (!TryGetEnumerator(sources, out var e))
+            if (!TryGetEnumerator(sources, out var current))
                 return Disposable.Empty;
 
-            _stack.Push(e);
-            _length.Push(Helpers.GetLength(sources));
+            stack = new Stack<IEnumerator<IObservable<TSource>>>();
+            stack.Push(current);
 
-            var cancelable = SchedulerDefaults.TailRecursion.Schedule(self =>
+            Drain();
+
+            return new RecursiveSinkDisposable(this);
+        }
+
+        sealed class RecursiveSinkDisposable : IDisposable
+        {
+            readonly TailRecursiveSink<TSource> parent;
+
+            public RecursiveSinkDisposable(TailRecursiveSink<TSource> parent)
             {
-                _recurse = self;
-                _gate.Wait(MoveNext);
-            });
+                this.parent = parent;
+            }
 
-            return StableCompositeDisposable.Create(_subscription, cancelable, Disposable.Create(() => _gate.Wait(Dispose)));
+            public void Dispose()
+            {
+                parent.DisposeAll();
+            }
+        }
+
+        void Drain()
+        {
+            if (Interlocked.Increment(ref trampoline) != 1)
+            {
+                return;
+            }
+
+            for (; ; )
+            {
+                if (Volatile.Read(ref _isDisposed))
+                {
+                    while (stack.Count != 0)
+                    {
+                        var enumerator = stack.Pop();
+                        enumerator.Dispose();
+                    }
+                    if (Volatile.Read(ref currentSubscription) != BooleanDisposable.True)
+                    {
+                        Interlocked.Exchange(ref currentSubscription, BooleanDisposable.True)?.Dispose();
+                    }
+                }
+                else
+                {
+                    if (stack.Count != 0)
+                    {
+                        var currentEnumerator = stack.Peek();
+
+                        var currentObservable = default(IObservable<TSource>);
+                        var next = default(IObservable<TSource>);
+
+                        try
+                        {
+                            if (currentEnumerator.MoveNext())
+                            {
+                                currentObservable = currentEnumerator.Current;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            currentEnumerator.Dispose();
+                            ForwardOnError(ex);
+                            Volatile.Write(ref _isDisposed, true);
+                            continue;
+                        }
+
+                        try
+                        {
+                            next = Helpers.Unpack(currentObservable);
+                            
+                        }
+                        catch (Exception ex)
+                        {
+                            next = null;
+                            if (!Fail(ex))
+                            {
+                                Volatile.Write(ref _isDisposed, true);
+                            }
+                            continue;
+                        }
+
+                        if (next != null)
+                        {
+                            var nextSeq = Extract(next);
+                            if (nextSeq != null)
+                            {
+                                if (TryGetEnumerator(nextSeq, out var nextEnumerator))
+                                {
+                                    stack.Push(nextEnumerator);
+                                    continue;
+                                }
+                                else
+                                {
+                                    Volatile.Write(ref _isDisposed, true);
+                                    continue;
+                                }
+                            }
+                            else
+                            {
+                                var sad = new SingleAssignmentDisposable();
+                                if (Interlocked.CompareExchange(ref currentSubscription, sad, null) == null)
+                                {
+                                    sad.Disposable = next.SubscribeSafe(this);
+                                }
+                                else
+                                {
+                                    continue;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            stack.Pop();
+                            currentEnumerator.Dispose();
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        Volatile.Write(ref _isDisposed, true);
+                        Done();
+                    }
+                }
+
+                if (Interlocked.Decrement(ref trampoline) == 0)
+                {
+                    break;
+                }
+            }
+        }
+
+        void DisposeAll()
+        {
+            Volatile.Write(ref _isDisposed, true);
+            // the disposing of currentSubscription is deferred to drain due to some ObservableExTest.Iterate_Complete()
+            // Interlocked.Exchange(ref currentSubscription, BooleanDisposable.True)?.Dispose();
+            Drain();
+        }
+
+        protected void Recurse()
+        {
+            var d = Volatile.Read(ref currentSubscription);
+            if (d != BooleanDisposable.True)
+            {
+                d?.Dispose();
+                if (Interlocked.CompareExchange(ref currentSubscription, null, d) == d)
+                {
+                    Drain();
+                }
+            }
         }
 
         protected abstract IEnumerable<IObservable<TSource>> Extract(IObservable<TSource> source);
 
+        /*
         private void MoveNext()
         {
             var hasNext = false;
@@ -158,19 +297,7 @@ namespace System.Reactive
             _subscription.Disposable = d;
             d.Disposable = next.SubscribeSafe(this);
         }
-
-        private new void Dispose()
-        {
-            while (_stack.Count > 0)
-            {
-                var e = _stack.Pop();
-                _length.Pop();
-
-                e.Dispose();
-            }
-
-            _isDisposed = true;
-        }
+        */
 
         private bool TryGetEnumerator(IEnumerable<IObservable<TSource>> sources, out IEnumerator<IObservable<TSource>> result)
         {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq.ObservableImpl
             public override void OnError(Exception error)
             {
                 _lastException = error;
-                _recurse();
+                Recurse();
             }
 
             protected override void Done()

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/OnErrorResumeNext.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/OnErrorResumeNext.cs
@@ -36,12 +36,12 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnError(Exception error)
             {
-                _recurse();
+                Recurse();
             }
 
             public override void OnCompleted()
             {
-                _recurse();
+                Recurse();
             }
 
             protected override bool Fail(Exception error)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sum.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sum.cs
@@ -4,6 +4,22 @@
 
 namespace System.Reactive.Linq.ObservableImpl
 {
+    internal abstract class SumSink<T> : IdentitySink<T>
+    {
+        protected T _sum;
+
+        protected SumSink(IObserver<T> observer, IDisposable cancel)
+            : base(observer, cancel)
+        {
+        }
+
+        public override void OnCompleted()
+        {
+            base.ForwardOnNext(_sum);
+            base.ForwardOnCompleted();
+        }
+    }
+
     internal sealed class SumDouble : Producer<double, SumDouble._>
     {
         private readonly IObservable<double> _source;
@@ -17,25 +33,16 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : IdentitySink<double>
+        internal sealed class _ : SumSink<double>
         {
-            private double _sum;
-
             public _(IObserver<double> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
-                _sum = 0.0;
             }
 
             public override void OnNext(double value)
             {
                 _sum += value;
-            }
-
-            public override void OnCompleted()
-            {
-                base.ForwardOnNext(_sum);
-                base.ForwardOnCompleted();
             }
         }
     }
@@ -53,25 +60,16 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : IdentitySink<float>
+        internal sealed class _ : SumSink<float>
         {
-            private double _sum; // This is what LINQ to Objects does!
-
             public _(IObserver<float> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
-                _sum = 0.0; // This is what LINQ to Objects does!
             }
 
             public override void OnNext(float value)
             {
                 _sum += value; // This is what LINQ to Objects does!
-            }
-
-            public override void OnCompleted()
-            {
-                base.ForwardOnNext((float)_sum); // This is what LINQ to Objects does!
-                base.ForwardOnCompleted();
             }
         }
     }
@@ -89,25 +87,16 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : IdentitySink<decimal>
+        internal sealed class _ : SumSink<decimal>
         {
-            private decimal _sum;
-
             public _(IObserver<decimal> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
-                _sum = 0M;
             }
 
             public override void OnNext(decimal value)
             {
                 _sum += value;
-            }
-
-            public override void OnCompleted()
-            {
-                base.ForwardOnNext(_sum);
-                base.ForwardOnCompleted();
             }
         }
     }
@@ -125,14 +114,11 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : IdentitySink<int>
+        internal sealed class _ : SumSink<int>
         {
-            private int _sum;
-
             public _(IObserver<int> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
-                _sum = 0;
             }
 
             public override void OnNext(int value)
@@ -148,12 +134,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     base.ForwardOnError(exception);
                 }
-            }
-            
-            public override void OnCompleted()
-            {
-                base.ForwardOnNext(_sum);
-                base.ForwardOnCompleted();
             }
         }
     }
@@ -171,14 +151,11 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : IdentitySink<long>
+        internal sealed class _ : SumSink<long>
         {
-            private long _sum;
-
             public _(IObserver<long> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
-                _sum = 0L;
             }
 
             public override void OnNext(long value)
@@ -194,12 +171,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     base.ForwardOnError(exception);
                 }
-            }
-
-            public override void OnCompleted()
-            {
-                base.ForwardOnNext(_sum);
-                base.ForwardOnCompleted();
             }
         }
     }
@@ -217,10 +188,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : IdentitySink<double?>
+        internal sealed class _ : SumSink<double?>
         {
-            private double _sum;
-
             public _(IObserver<double?> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
@@ -231,12 +200,6 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (value != null)
                     _sum += value.Value;
-            }
-
-            public override void OnCompleted()
-            {
-                base.ForwardOnNext(_sum);
-                base.ForwardOnCompleted();
             }
         }
     }
@@ -272,12 +235,12 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnCompleted()
             {
-                base.ForwardOnNext((float)_sum); // This is what LINQ to Objects does!
+                base.ForwardOnNext((float) _sum); // This is what LINQ to Objects does!
                 base.ForwardOnCompleted();
             }
         }
     }
-
+    
     internal sealed class SumDecimalNullable : Producer<decimal?, SumDecimalNullable._>
     {
         private readonly IObservable<decimal?> _source;
@@ -291,10 +254,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : IdentitySink<decimal?>
+        internal sealed class _ : SumSink<decimal?>
         {
-            private decimal _sum;
-
             public _(IObserver<decimal?> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
@@ -305,12 +266,6 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (value != null)
                     _sum += value.Value;
-            }
-
-            public override void OnCompleted()
-            {
-                base.ForwardOnNext(_sum);
-                base.ForwardOnCompleted();
             }
         }
     }
@@ -328,10 +283,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : IdentitySink<int?>
+        internal sealed class _ : SumSink<int?>
         {
-            private int _sum;
-
             public _(IObserver<int?> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
@@ -353,12 +306,6 @@ namespace System.Reactive.Linq.ObservableImpl
                     base.ForwardOnError(exception);
                 }
             }
-
-            public override void OnCompleted()
-            {
-                base.ForwardOnNext(_sum);
-                base.ForwardOnCompleted();
-            }
         }
     }
 
@@ -375,10 +322,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : IdentitySink<long?>
+        internal sealed class _ : SumSink<long?>
         {
-            private long _sum;
-
             public _(IObserver<long?> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
@@ -399,12 +344,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     base.ForwardOnError(exception);
                 }
-            }
-
-            public override void OnCompleted()
-            {
-                base.ForwardOnNext(_sum);
-                base.ForwardOnCompleted();
             }
         }
     }


### PR DESCRIPTION
This PR changes `TailRecursiveSink` to a lock-free algorithm as well as reduces the allocations in the class by inlining various `IDisposable` fields.

The aim of the class is to make sure `OnComplete` or `OnError` in `Concat`, `Catch` and various other operators don't trigger an infinite recursion but stay on the level. 

This could have been solved with a straightforward trampoline [like this `Concat` implementation](https://github.com/dotnet/reactive/pull/491/files), however, there is a small complication. The recursion may be not only on the termination side, but on the existence of the inner `IObservable`s. 

For example, to avoid yet another level of recursion due to graphs like `Concat(Concat(a, b), Concat(c, d))`, the `Extract` method can get another level of `IEnumerable<IObservable<TSource>>` on the current level, and the concatenation should resume on the inner `Concat`. 

The `Stack` is there to allow returning to an outer enumeration and resume it. I don't know what the length stack was supposed to do; the algorithm doesn't have to know how long each `IEnumerator` is. Was it some kind of optimization for Lists and arrays avoiding `MoveNext() == false` and thus `IEnumerator.Dispose()`? The former should be as costly as an index comparison and the latter should be no-op anyway.

Further allocations have been likely avoided by using a static delegate in `Producer`s because due to `this.Run` method reference, the schedule call will create a new delegate to capture `this`.